### PR TITLE
Replace gsed with sed in order to fix issue

### DIFF
--- a/bootSimulator.plugin.zsh
+++ b/bootSimulator.plugin.zsh
@@ -57,7 +57,7 @@ bootSimulator() {
 
     n=1
     while read line; do
-        echo $n. $line | gsed -E "s/\([A-Z0-9]{8}(-[A-Z0-9]{4}){3}-[A-Z0-9]{12}\).*//g"
+        echo $n. $line | sed -E "s/\([A-Z0-9]{8}(-[A-Z0-9]{4}){3}-[A-Z0-9]{12}\).*//g"
         n=$((n + 1))
     done <$devicesForVersion
 


### PR DESCRIPTION
Hi!
I wanted to say thank you for the great script by trying to contribute to the repository.
On my end, instead of the iPhone devices' names, all I got was `command gsed not found`.
That is why I decided to make this little fix replacing `gsed` with `sed` because I think that more people will face the same problem.
Any reviews and/or comments about the issue are welcome.
